### PR TITLE
Add calledFromDealloc parameter to dispose method

### DIFF
--- a/just_audio/macos/Classes/AudioPlayer.h
+++ b/just_audio/macos/Classes/AudioPlayer.h
@@ -7,7 +7,7 @@
 @property (readonly, nonatomic) float speed;
 
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar playerId:(NSString*)idParam loadConfiguration:(NSDictionary *)loadConfiguration;
-- (void)dispose;
+- (void)dispose:(BOOL)calledFromDealloc;
 
 @end
 


### PR DESCRIPTION
## Summary
Modified the `dispose` method signature in the AudioPlayer class to accept a boolean parameter indicating whether the method was called from the dealloc lifecycle event.

## Key Changes
- Updated `dispose` method signature from `- (void)dispose;` to `- (void)dispose:(BOOL)calledFromDealloc;`
- This allows the dispose logic to differentiate between explicit disposal and cleanup during object deallocation

## Implementation Details
The parameter enables the AudioPlayer to handle cleanup differently depending on the context in which disposal occurs, which is useful for managing resources and avoiding potential issues during object lifecycle transitions.

https://claude.ai/code/session_01N5kKiBJKmqREvwkMkd1tbR